### PR TITLE
Update pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   http: ^1.2.0
   crypto: ^3.0.0
-  lints: ^3.0.0
 
 dev_dependencies:
   test: ^1.25.0
+  lints: ^3.0.0


### PR DESCRIPTION
The `lints` package should be in the dev_dependencies section, otherwise it may cause conflicts with other link packages chosen by the developers, like `flutter_lints`

More info:
https://pub.dev/packages/lints/install