### PR TITLE
Fix OdooSession serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # odoo_rpc changelog
 
+## 0.5.8
+
+Fixed OdooSession serialization issue.
+
 ## 0.5.7
 
 Fixed type casting for allowedCompanies as list of Company records.

--- a/lib/src/odoo_session.dart
+++ b/lib/src/odoo_session.dart
@@ -38,7 +38,6 @@ class Company {
   }
 }
 
-
 /// Represents session with Odoo server.
 class OdooSession {
   /// Current Session id
@@ -109,7 +108,8 @@ class OdooSession {
       companyId = info['company_id'] as int? ?? 0;
     }
     // since Odoo 13.0
-    if (info.containsKey('user_companies') && (info['user_companies'] is! bool)) {
+    if (info.containsKey('user_companies') &&
+        (info['user_companies'] is! bool)) {
       var sessionCurrentCompany = info['user_companies']['current_company'];
       if (sessionCurrentCompany is List) {
         // 12.0, 13.0, 14.0
@@ -123,7 +123,8 @@ class OdooSession {
       if (sessionAllowedCompanies is Map) {
         // since 15.0
         for (var e in sessionAllowedCompanies.values) {
-          allowedCompanies.add(Company(id: e['id'] as int, name: e['name'] as String));
+          allowedCompanies
+              .add(Company(id: e['id'] as int, name: e['name'] as String));
         }
       }
       if (sessionAllowedCompanies is List) {
@@ -174,7 +175,8 @@ class OdooSession {
       userId: json['userId'] as int,
       partnerId: json['partnerId'] as int,
       companyId: json['companyId'] as int,
-      allowedCompanies: Company.fromJsonList(List<Map<String, dynamic>>.from(json['allowedCompanies'])),
+      allowedCompanies: Company.fromJsonList(
+          List<Map<String, dynamic>>.from(json['allowedCompanies'])),
       userLogin: json['userLogin'] as String,
       userName: json['userName'] as String,
       userLang: json['userLang'] as String,
@@ -210,7 +212,9 @@ class OdooSession {
   /// ```
   int get serverVersionInt {
     // Take last two chars for name like 'saas~14'
-    final serverVersionSanitized = serverVersion.length == 1 ? serverVersion : serverVersion.substring(serverVersion.length - 2);
+    final serverVersionSanitized = serverVersion.length == 1
+        ? serverVersion
+        : serverVersion.substring(serverVersion.length - 2);
     return int.tryParse(serverVersionSanitized) ?? -1;
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: odoo_rpc
 description: Odoo RPC Client library for Dart with session changes tracking via stream.
-version: 0.5.7
+version: 0.5.8
 homepage: https://github.com/ERP-Ukraine/odoo-rpc-dart
 repository: https://github.com/ERP-Ukraine/odoo-rpc-dart
 

--- a/test/odoo_rpc_test.dart
+++ b/test/odoo_rpc_test.dart
@@ -17,8 +17,10 @@ class OdooSessionMatcher extends Matcher {
   }
 
   @override
-  Description describeMismatch(dynamic item, Description mismatchDescription, Map<dynamic, dynamic> matchState, bool verbose) {
-    return mismatchDescription.add("has actual emitted session = '${matchState['actual'].id}'");
+  Description describeMismatch(dynamic item, Description mismatchDescription,
+      Map<dynamic, dynamic> matchState, bool verbose) {
+    return mismatchDescription
+        .add("has actual emitted session = '${matchState['actual'].id}'");
   }
 
   @override
@@ -124,32 +126,39 @@ void main() {
   group('RPC Calls', () {
     test('Test initial session', () {
       var mockHttpClient = http_testing.MockClient(getFakeRequestHandler(200));
-      var client = OdooClient('https://demo.erp.co.ua', initialSession, mockHttpClient);
+      var client =
+          OdooClient('https://demo.erp.co.ua', initialSession, mockHttpClient);
       expect(client.sessionId!.id, equals(initialSession.id));
     });
     test('Test refreshing session', () async {
       var mockHttpClient = http_testing.MockClient(getFakeRequestHandler(200));
 
-      var client = OdooClient('https://demo.erp.co.ua', initialSession, mockHttpClient);
+      var client =
+          OdooClient('https://demo.erp.co.ua', initialSession, mockHttpClient);
 
       expect(client.sessionId!.id, equals(initialSession.id));
 
       final expectedSessionId = checksum('/some/path');
-      var expectForEvent = expectLater(client.sessionStream, emits(OdooSessionMatcher(expectedSessionId)));
+      var expectForEvent = expectLater(
+          client.sessionStream, emits(OdooSessionMatcher(expectedSessionId)));
       await client.callRPC('/some/path', 'funcName', {});
       expect(client.sessionId!.id, equals(expectedSessionId));
       await expectForEvent;
     });
     test('Test expired session exception', () {
       var mockHttpClient = http_testing.MockClient(getFakeRequestHandler(100));
-      var client = OdooClient('https://demo.erp.co.ua', initialSession, mockHttpClient);
-      expect(() async => await client.callRPC('/some/path', 'funcName', {}), throwsA(TypeMatcher<OdooSessionExpiredException>()));
+      var client =
+          OdooClient('https://demo.erp.co.ua', initialSession, mockHttpClient);
+      expect(() async => await client.callRPC('/some/path', 'funcName', {}),
+          throwsA(TypeMatcher<OdooSessionExpiredException>()));
     });
 
     test('Test server error exception', () {
       var mockHttpClient = http_testing.MockClient(getFakeRequestHandler(500));
-      var client = OdooClient('https://demo.erp.co.ua', initialSession, mockHttpClient);
-      expect(() async => await client.callRPC('/some/path', 'funcName', {}), throwsA(TypeMatcher<OdooException>()));
+      var client =
+          OdooClient('https://demo.erp.co.ua', initialSession, mockHttpClient);
+      expect(() async => await client.callRPC('/some/path', 'funcName', {}),
+          throwsA(TypeMatcher<OdooException>()));
     });
   });
 


### PR DESCRIPTION
This PR addresses issue #63  by updating the implementation related to the `Company` type. In previous versions, the `Company` type was defined using `Record`, which caused serialization errors when trying to serialize the `OdooSession` object, as `Record` types are not serializable.

This simple example will result in a serialization error:
```dart
import 'dart:convert';

typedef Company = ({
  int id,
  String name,
});

void main() async {
  var company = (id: 1, name: "Company");
  json.encode(company);
}
```